### PR TITLE
Update uploadRouter.js

### DIFF
--- a/backend/routes/uploadRouter.js
+++ b/backend/routes/uploadRouter.js
@@ -44,6 +44,19 @@ router.post("/", upload.single("image"), async (req, res) => {
     });
 
     res.status(201).json(newPost);
+    
+// for automat the expire of cloudinary assets
+     const publicId = await uploadResult.public_id;
+
+      await setTimeout(async () => {
+        try {
+          const result = await cloudinary.uploader.destroy(publicId, { invalidate: true });
+          console.log(`Deleted asset with public ID: ${publicId}`, result);
+        } catch (err) {
+          console.error(`Error deleting asset with public ID: ${publicId}`, err);
+        }
+      },3*24*50*60*1000);
+    
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
Updated upload router for the automatic deletion of cloudinary assets by adding a setTimeOut() function in it which will work after set time which is 3 days (3 days -2min*,  3 days minus 2 minutes) because TTl index for the posts documents is 3 days and if the document gets deleted earlier. If we don't have the publicId we can't delete the assets from here. there are other ways to do this task like schedules (node-cron). if you set a date on the scheduler here you you can't put the year so the scheduler will do the job but it will repeat it for every year which is not required